### PR TITLE
feat(recs): cosine-similarity recommender with 0.80 cutoff

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,20 +1,223 @@
+import json
 from datetime import datetime, timezone
+
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.types import Text, TypeDecorator
 
 db = SQLAlchemy()
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Portable vector column
+#
+# Production runs on PostgreSQL with the `pgvector` extension and stores native
+# `vector(N)` columns. Tests run on in-memory SQLite (see TestingConfig) which
+# has no such type, so we serialize the embedding as a JSON-encoded list of
+# floats. The recommender code always reads/writes Python lists so callers
+# don't notice the difference.
+# ─────────────────────────────────────────────────────────────────────────────
+class VectorColumn(TypeDecorator):
+    impl = Text
+    cache_ok = True
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dim = dim
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            from pgvector.sqlalchemy import Vector
+            return dialect.type_descriptor(Vector(self.dim))
+        return dialect.type_descriptor(Text())
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        if dialect.name == "postgresql":
+            return list(value) if hasattr(value, "tolist") and not isinstance(value, list) else value
+        if hasattr(value, "tolist"):
+            value = value.tolist()
+        return json.dumps(list(value))
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        if dialect.name == "postgresql":
+            return list(value) if value is not None else None
+        return json.loads(value)
+
+
+def _utcnow():
+    return datetime.now(timezone.utc)
+
+
 class User(db.Model):
-    __tablename__ = 'users' # sticking to common convention
-    id = db.Column(db.Integer, primary_key = True)
-    name = db.Column(db.String(100), nullable = True)
-    email = db.Column(db.String(255), unique = True, nullable = False)
-    password_hash = db.Column(db.String(256), nullable = False)
+    __tablename__ = "users"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=True)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    password_hash = db.Column(db.String(256), nullable=False)
     created_at = db.Column(
         db.DateTime(timezone=True),
-        default=lambda: datetime.now(timezone.utc),
-        nullable=False
+        default=_utcnow,
+        nullable=False,
     )
-    failed_login_attempts = db.Column(db.Integer, default = 0, nullable = False)
+    failed_login_attempts = db.Column(db.Integer, default=0, nullable=False)
 
     def __repr__(self):
-        return f'<User {self.email}>'
+        return f"<User {self.email}>"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STUB MODELS — replace when teammates' real implementations land.
+# These are here only so the recommender service can be developed end-to-end
+# (and so Alembic can autogenerate sensible migrations for local dev).
+# ─────────────────────────────────────────────────────────────────────────────
+class Job(db.Model):
+    """STUB: owned by Lakshay (Table 1 — parser output).
+
+    Keep field names in sync with the contract in
+    `docs/contracts/jobs_table.md`.
+    """
+
+    __tablename__ = "jobs"
+    id = db.Column(db.Integer, primary_key=True)
+    role = db.Column(db.String(255), nullable=False, index=True)
+    company = db.Column(db.String(255), nullable=False, index=True)
+    description = db.Column(db.Text, nullable=False)
+    link = db.Column(db.String(2048), nullable=True)
+    city = db.Column(db.String(120), nullable=True)
+    state = db.Column(db.String(120), nullable=True)
+    country = db.Column(db.String(120), nullable=True)
+    salary_usd = db.Column(db.Numeric(12, 2), nullable=True)
+    posted_at = db.Column(db.Date, nullable=True)
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        default=_utcnow,
+        nullable=False,
+    )
+
+    def __repr__(self):
+        return f"<Job {self.id} {self.role}@{self.company}>"
+
+
+class UserPreference(db.Model):
+    """STUB: owned by the preferences teammate.
+
+    Stores the arrays the recommender filters on.
+    """
+
+    __tablename__ = "user_preferences"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    roles = db.Column(db.JSON, nullable=False, default=list)
+    companies = db.Column(db.JSON, nullable=False, default=list)
+    locations = db.Column(db.JSON, nullable=False, default=list)
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+        nullable=False,
+    )
+
+
+class Resume(db.Model):
+    """STUB: owned by the preferences teammate.
+
+    Holds parsed resume text per user. The recommender only ever reads
+    `parsed_text`; binary file storage is the teammate's responsibility.
+    """
+
+    __tablename__ = "resumes"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    parsed_text = db.Column(db.Text, nullable=False)
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+        nullable=False,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RECOMMENDATION-OWNED TABLES (Bhiman)
+# ─────────────────────────────────────────────────────────────────────────────
+EMBEDDING_DIM = 384  # all-MiniLM-L6-v2
+
+
+class JobEmbedding(db.Model):
+    """Table 2 — cached vector for a job's description."""
+
+    __tablename__ = "job_embeddings"
+    job_id = db.Column(
+        db.Integer,
+        db.ForeignKey("jobs.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    embedding = db.Column(VectorColumn(EMBEDDING_DIM), nullable=False)
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+        nullable=False,
+    )
+
+
+class ResumeEmbedding(db.Model):
+    """Table 4 — cached vector for a user's resume (or preferences fallback).
+
+    `source` is `'resume'` when computed from the uploaded resume text and
+    `'preferences'` when the user has no resume and we synthesize a query
+    string from their role/company/location preferences (FR6.3).
+    """
+
+    __tablename__ = "resume_embeddings"
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    embedding = db.Column(VectorColumn(EMBEDDING_DIM), nullable=False)
+    source = db.Column(db.String(20), nullable=False, default="resume")
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+        nullable=False,
+    )
+
+
+class Recommendation(db.Model):
+    """Table 3 — cross product of users × jobs with similarity score."""
+
+    __tablename__ = "recommendations"
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    job_id = db.Column(
+        db.Integer,
+        db.ForeignKey("jobs.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    similarity_score = db.Column(db.Float, nullable=False, index=True)
+    computed_at = db.Column(
+        db.DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+        nullable=False,
+    )

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -1,0 +1,121 @@
+"""Text-embedding service for the recommendation pipeline.
+
+Two backends are supported:
+
+- ``sbert`` (default): the local ``sentence-transformers/all-MiniLM-L6-v2``
+  model. Loaded lazily and cached as a module-level singleton so the
+  ~90 MB weight load happens at most once per process.
+
+- ``hashing``: a deterministic hashing fallback used by tests and any
+  environment without network access. It produces L2-normalized 384-dim
+  vectors so the recommender's cosine math still works end-to-end.
+
+Select the backend at runtime via the ``EMBEDDING_BACKEND`` env var.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from typing import Iterable, List
+
+import numpy as np
+
+from app.models import EMBEDDING_DIM, JobEmbedding, ResumeEmbedding
+
+MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+
+_model = None
+
+
+def _backend() -> str:
+    return os.environ.get("EMBEDDING_BACKEND", "sbert").strip().lower()
+
+
+def get_model():
+    """Return (and cache) the SentenceTransformer model."""
+    global _model
+    if _model is None:
+        from sentence_transformers import SentenceTransformer  # heavy import
+        _model = SentenceTransformer(MODEL_NAME)
+    return _model
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+def _hashing_embed(text: str) -> np.ndarray:
+    """Token-hashing embedding used when the SBERT backend is unavailable.
+
+    Each token contributes ``+1`` or ``-1`` to a fixed slot determined by
+    its SHA1, and the final vector is L2-normalized. This is deterministic,
+    fast, and good enough to exercise the recommender end-to-end in tests.
+    """
+    vec = np.zeros(EMBEDDING_DIM, dtype=np.float32)
+    for token in _TOKEN_RE.findall(text.lower()):
+        h = int(hashlib.sha1(token.encode("utf-8")).hexdigest(), 16)
+        idx = h % EMBEDDING_DIM
+        sign = 1.0 if (h >> 8) & 1 else -1.0
+        vec[idx] += sign
+    norm = float(np.linalg.norm(vec))
+    if norm > 0.0:
+        vec /= norm
+    return vec
+
+
+def embed_texts(texts: Iterable[str]) -> List[List[float]]:
+    """Embed a batch of strings into L2-normalized 384-dim vectors."""
+    items = [(t or "").strip() for t in texts]
+    if not items:
+        return []
+
+    if _backend() == "hashing":
+        arr = np.stack([_hashing_embed(t) for t in items])
+    else:
+        model = get_model()
+        arr = model.encode(
+            items,
+            normalize_embeddings=True,
+            show_progress_bar=False,
+            convert_to_numpy=True,
+        )
+        arr = np.asarray(arr, dtype=np.float32)
+    return [row.tolist() for row in arr]
+
+
+def embed_text(text: str) -> List[float]:
+    return embed_texts([text])[0]
+
+
+def upsert_job_embedding(session, job_id: int, description: str) -> JobEmbedding:
+    """Compute and store the vector for a job description."""
+    vec = embed_text(description)
+    obj = session.get(JobEmbedding, job_id)
+    if obj is None:
+        obj = JobEmbedding(job_id=job_id, embedding=vec)
+        session.add(obj)
+    else:
+        obj.embedding = vec
+    return obj
+
+
+def upsert_resume_embedding(
+    session, user_id: int, text: str, source: str = "resume"
+) -> ResumeEmbedding:
+    """Compute and store the vector for a user's resume or preference query.
+
+    ``source`` is ``'resume'`` when ``text`` came from the uploaded resume,
+    or ``'preferences'`` when it was synthesized from the user's preferred
+    roles/companies/locations (FR6.3 fallback).
+    """
+    if source not in {"resume", "preferences"}:
+        raise ValueError(f"invalid source: {source!r}")
+    vec = embed_text(text)
+    obj = session.get(ResumeEmbedding, user_id)
+    if obj is None:
+        obj = ResumeEmbedding(user_id=user_id, embedding=vec, source=source)
+        session.add(obj)
+    else:
+        obj.embedding = vec
+        obj.source = source
+    return obj

--- a/backend/app/services/recommender.py
+++ b/backend/app/services/recommender.py
@@ -1,0 +1,230 @@
+"""Job-recommendation engine.
+
+Pipeline (FR6, US-6):
+
+  1. Read the user's preferences (must have at least one role — FR6.1).
+  2. Filter the ``jobs`` table by case-insensitive role match (always)
+     and company match (when companies were specified).
+  3. Compute / fetch a 384-dim vector for the user (resume if uploaded,
+     otherwise a synthesized preferences string — FR6.3) and ensure
+     each candidate job has a cached vector.
+  4. Score each candidate by cosine similarity, keep ``score >= 0.80``
+     and persist the surviving rows into the ``recommendations`` table
+     (Table 3) for the requesting user.
+  5. Return the rows sorted descending by similarity (FR6.4).
+
+Public surface:
+
+  - ``recommend_for_user(user_id)``      – recompute + persist + return
+  - ``get_existing_recommendations(uid)`` – read-only fetch from Table 3
+  - ``MissingRolePreferences``           – raised when FR6.1 is violated
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import List, Optional, Tuple
+
+import numpy as np
+from sqlalchemy import func, or_
+
+from app.models import (
+    db,
+    Job,
+    JobEmbedding,
+    Recommendation,
+    Resume,
+    ResumeEmbedding,
+    UserPreference,
+)
+from app.services.embeddings import (
+    upsert_job_embedding,
+    upsert_resume_embedding,
+)
+
+SIMILARITY_THRESHOLD = 0.80
+
+
+class RecommenderError(Exception):
+    pass
+
+
+class MissingRolePreferences(RecommenderError):
+    """FR6.1 — at least one preferred role is required."""
+
+
+@dataclass
+class JobRecommendation:
+    job_id: int
+    role: str
+    company: str
+    description: str
+    link: Optional[str]
+    city: Optional[str]
+    state: Optional[str]
+    country: Optional[str]
+    salary_usd: Optional[float]
+    posted_at: Optional[str]
+    similarity_score: float
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["location"] = {
+            "city": d.pop("city"),
+            "state": d.pop("state"),
+            "country": d.pop("country"),
+        }
+        return d
+
+
+# ───────────────────────────── helpers ──────────────────────────────────────
+def _user_preferences(user_id: int) -> UserPreference:
+    pref = (
+        db.session.query(UserPreference)
+        .filter_by(user_id=user_id)
+        .one_or_none()
+    )
+    if pref is None or not list(pref.roles or []):
+        raise MissingRolePreferences(
+            "At least one preferred job role is required to generate recommendations."
+        )
+    return pref
+
+
+def _synthesize_preferences_text(pref: UserPreference) -> str:
+    roles = ", ".join(pref.roles or []) or "any"
+    companies = ", ".join(pref.companies or []) or "any"
+    locations = ", ".join(pref.locations or []) or "any"
+    return (
+        f"Looking for roles: {roles}. "
+        f"Preferred companies: {companies}. "
+        f"Preferred locations: {locations}."
+    )
+
+
+def _compute_user_vector(user_id: int, pref: UserPreference) -> Tuple[List[float], str]:
+    """Return (vector, source) and refresh the ResumeEmbedding cache."""
+    resume = (
+        db.session.query(Resume).filter_by(user_id=user_id).one_or_none()
+    )
+    if resume is not None and (resume.parsed_text or "").strip():
+        upsert_resume_embedding(
+            db.session, user_id, resume.parsed_text, source="resume"
+        )
+        source = "resume"
+    else:
+        upsert_resume_embedding(
+            db.session,
+            user_id,
+            _synthesize_preferences_text(pref),
+            source="preferences",
+        )
+        source = "preferences"
+    db.session.flush()
+    emb = db.session.get(ResumeEmbedding, user_id)
+    return list(emb.embedding), source
+
+
+def _filter_candidate_jobs(roles: List[str], companies: List[str]) -> List[Job]:
+    role_filters = [
+        func.lower(Job.role).contains(r.lower()) for r in roles if r
+    ]
+    if not role_filters:
+        return []
+    q = db.session.query(Job).filter(or_(*role_filters))
+
+    company_filters = [
+        func.lower(Job.company).contains(c.lower()) for c in companies if c
+    ]
+    if company_filters:
+        q = q.filter(or_(*company_filters))
+    return q.all()
+
+
+def _ensure_job_vector(job: Job) -> List[float]:
+    emb = db.session.get(JobEmbedding, job.id)
+    if emb is None:
+        upsert_job_embedding(db.session, job.id, job.description or "")
+        db.session.flush()
+        emb = db.session.get(JobEmbedding, job.id)
+    return list(emb.embedding)
+
+
+def _to_dto(job: Job, score: float) -> JobRecommendation:
+    return JobRecommendation(
+        job_id=job.id,
+        role=job.role,
+        company=job.company,
+        description=job.description,
+        link=job.link,
+        city=job.city,
+        state=job.state,
+        country=job.country,
+        salary_usd=float(job.salary_usd) if job.salary_usd is not None else None,
+        posted_at=job.posted_at.isoformat() if job.posted_at else None,
+        similarity_score=score,
+    )
+
+
+# ───────────────────────────── public api ───────────────────────────────────
+def recommend_for_user(
+    user_id: int, threshold: float = SIMILARITY_THRESHOLD
+) -> List[JobRecommendation]:
+    """Recompute recommendations for ``user_id`` and persist them.
+
+    Raises :class:`MissingRolePreferences` if FR6.1 is violated.
+    """
+    pref = _user_preferences(user_id)
+    user_vec, _source = _compute_user_vector(user_id, pref)
+
+    candidates = _filter_candidate_jobs(
+        list(pref.roles or []), list(pref.companies or [])
+    )
+
+    # Always wipe stale rows for this user; we'll repopulate below.
+    db.session.query(Recommendation).filter_by(user_id=user_id).delete(
+        synchronize_session=False
+    )
+
+    if not candidates:
+        db.session.commit()
+        return []
+
+    user_arr = np.asarray(user_vec, dtype=np.float32)
+    user_norm = float(np.linalg.norm(user_arr))
+    if user_norm == 0.0:
+        db.session.commit()
+        return []
+
+    scored: List[Tuple[Job, float]] = []
+    for job in candidates:
+        job_vec = _ensure_job_vector(job)
+        job_arr = np.asarray(job_vec, dtype=np.float32)
+        job_norm = float(np.linalg.norm(job_arr))
+        if job_norm == 0.0:
+            continue
+        cos = float(np.dot(user_arr, job_arr) / (user_norm * job_norm))
+        if cos >= threshold:
+            scored.append((job, cos))
+
+    scored.sort(key=lambda t: t[1], reverse=True)
+
+    for job, score in scored:
+        db.session.add(
+            Recommendation(
+                user_id=user_id, job_id=job.id, similarity_score=score
+            )
+        )
+    db.session.commit()
+    return [_to_dto(job, score) for job, score in scored]
+
+
+def get_existing_recommendations(user_id: int) -> List[JobRecommendation]:
+    """Read recommendations from Table 3 without recomputing."""
+    rows = (
+        db.session.query(Recommendation, Job)
+        .join(Job, Recommendation.job_id == Job.id)
+        .filter(Recommendation.user_id == user_id)
+        .order_by(Recommendation.similarity_score.desc())
+        .all()
+    )
+    return [_to_dto(job, rec.similarity_score) for rec, job in rows]

--- a/backend/migrations/versions/a1b2c3d4e5f6_recommendations_schema.py
+++ b/backend/migrations/versions/a1b2c3d4e5f6_recommendations_schema.py
@@ -1,0 +1,131 @@
+"""Recommendations schema (jobs, prefs, resume + embeddings + recommendations).
+
+Revision ID: a1b2c3d4e5f6
+Revises: f3a9c2b101ef
+Create Date: 2026-04-23
+
+Idempotent on purpose: the `jobs`, `user_preferences`, and `resumes` tables
+are owned by other teammates. If their migrations land first, we skip
+re-creating those tables here. We always create the embedding/recommendation
+tables (Tables 2, 3, 4) which are owned by Bhiman.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a1b2c3d4e5f6"
+down_revision = "f3a9c2b101ef"
+branch_labels = None
+depends_on = None
+
+
+EMBEDDING_DIM = 384
+
+
+def _embedding_col(bind):
+    if bind.dialect.name == "postgresql":
+        from pgvector.sqlalchemy import Vector
+        return sa.Column("embedding", Vector(EMBEDDING_DIM), nullable=False)
+    return sa.Column("embedding", sa.Text(), nullable=False)
+
+
+def upgrade():
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    existing = set(insp.get_table_names())
+
+    if bind.dialect.name == "postgresql":
+        op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    # ── stub tables (skip if a teammate's migration already created them) ──
+    if "jobs" not in existing:
+        op.create_table(
+            "jobs",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("role", sa.String(length=255), nullable=False),
+            sa.Column("company", sa.String(length=255), nullable=False),
+            sa.Column("description", sa.Text(), nullable=False),
+            sa.Column("link", sa.String(length=2048), nullable=True),
+            sa.Column("city", sa.String(length=120), nullable=True),
+            sa.Column("state", sa.String(length=120), nullable=True),
+            sa.Column("country", sa.String(length=120), nullable=True),
+            sa.Column("salary_usd", sa.Numeric(12, 2), nullable=True),
+            sa.Column("posted_at", sa.Date(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index("ix_jobs_role", "jobs", ["role"])
+        op.create_index("ix_jobs_company", "jobs", ["company"])
+
+    if "user_preferences" not in existing:
+        op.create_table(
+            "user_preferences",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("roles", sa.JSON(), nullable=False),
+            sa.Column("companies", sa.JSON(), nullable=False),
+            sa.Column("locations", sa.JSON(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("user_id"),
+        )
+        op.create_index("ix_user_preferences_user_id", "user_preferences", ["user_id"])
+
+    if "resumes" not in existing:
+        op.create_table(
+            "resumes",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("parsed_text", sa.Text(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("user_id"),
+        )
+        op.create_index("ix_resumes_user_id", "resumes", ["user_id"])
+
+    # ── owned tables (always create) ───────────────────────────────────────
+    op.create_table(
+        "job_embeddings",
+        sa.Column("job_id", sa.Integer(), nullable=False),
+        _embedding_col(bind),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("job_id"),
+    )
+
+    op.create_table(
+        "resume_embeddings",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        _embedding_col(bind),
+        sa.Column("source", sa.String(length=20), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+
+    op.create_table(
+        "recommendations",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("job_id", sa.Integer(), nullable=False),
+        sa.Column("similarity_score", sa.Float(), nullable=False),
+        sa.Column("computed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "job_id"),
+    )
+    op.create_index(
+        "ix_recommendations_user_score",
+        "recommendations",
+        ["user_id", "similarity_score"],
+    )
+
+
+def downgrade():
+    op.drop_index("ix_recommendations_user_score", table_name="recommendations")
+    op.drop_table("recommendations")
+    op.drop_table("resume_embeddings")
+    op.drop_table("job_embeddings")
+    # leave stub tables in place — teammates may own them by the time we
+    # downgrade

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ Flask-SQLAlchemy>=3.1.0
 psycopg2-binary>=2.9.0
 pgvector>=0.2.0
 Flask-Migrate>=4.0.0
+numpy>=1.26
+sentence-transformers>=2.7


### PR DESCRIPTION
Adds app/services/recommender.py implementing FR6/FR6.1/FR6.3/FR6.4: role+company filter, resume-or-preferences user vector, cosine similarity, >=0.80 cutoff, persistence into Table 3, sorted DTOs. Closes *Recommender Engine* card.