### PR TITLE
feat(profile): add post-login preferences onboarding gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ temp/
 
 # --- Database dumps (local backups) ---
 *.dump
+*.db

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ You need **both** servers running: Flask serves the JSON API; Vite serves the UI
 cd backend
 source .venv/bin/activate   # or Windows activate script above
 export FLASK_APP=wsgi:app
+flask db upgrade
 flask run
 ```
 
@@ -132,6 +133,20 @@ through the `jobs` blueprint:
 | `GET`  | `/api/jobs/<id>`                       | Full job detail for the details modal. |
 
 All three require a JWT in `Authorization: Bearer ...`.
+
+### Post-login preference gate
+
+After sign-in, JobPing checks `GET /api/profile/preferences/status`:
+
+- If at least one preferred role exists, the user is redirected to `/recommendations`.
+- If not, the user is redirected to `/preferences` first.
+
+The preferences form saves through `POST /api/profile/preferences` and enforces:
+
+- `roles[]` is required with at least one non-empty value.
+- `resume` is optional but recommended.
+- If a resume is provided, it must be a PDF and less than 5MB.
+- The backend stores parsed resume text in `resumes.parsed_text` (not raw PDF bytes).
 
 ### How matching works
 
@@ -175,6 +190,14 @@ cd backend
 source .venv/bin/activate
 EMBEDDING_BACKEND=hashing PYTHONPATH=. pytest -q
 ```
+
+### Manual frontend verification checklist
+
+1. Login with a brand-new account and confirm redirect to `/preferences`.
+2. Try saving with no role and confirm validation appears.
+3. Try uploading a non-PDF or file larger than 5MB and confirm validation appears.
+4. Save at least one role (with or without resume) and confirm redirect to `/recommendations`.
+5. Logout and login again with the same account; confirm direct redirect to `/recommendations`.
 
 ## Working with the team on Git
 

--- a/backend/app/blueprints/profile/routes.py
+++ b/backend/app/blueprints/profile/routes.py
@@ -1,6 +1,115 @@
+from flask import jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
 from app.blueprints.profile import bp
+from app.models import Resume, UserPreference, db
+from app.services.resume_parser import ResumeParseError, extract_text_from_pdf_bytes
+
+MAX_RESUME_BYTES = 5 * 1024 * 1024
+
+
+def _current_user_id() -> int | None:
+    sub = get_jwt_identity()
+    try:
+        return int(sub)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_roles(raw_roles) -> list[str]:
+    if not isinstance(raw_roles, list):
+        raise ValueError("roles must be an array")
+    cleaned = []
+    for role in raw_roles:
+        if not isinstance(role, str):
+            continue
+        text = role.strip()
+        if text:
+            cleaned.append(text)
+    if not cleaned:
+        raise ValueError("At least one job role is required.")
+    return cleaned
 
 
 @bp.get("/health")
 def health():
     return {"blueprint": "profile"}
+
+
+@bp.get("/preferences/status")
+@jwt_required()
+def preferences_status():
+    uid = _current_user_id()
+    if uid is None:
+        return jsonify({"error": "Invalid token subject."}), 422
+
+    pref = db.session.query(UserPreference).filter_by(user_id=uid).one_or_none()
+    resume = db.session.query(Resume).filter_by(user_id=uid).one_or_none()
+
+    roles = list(pref.roles or []) if pref is not None else []
+    has_roles = any(isinstance(role, str) and role.strip() for role in roles)
+    has_resume = bool(resume is not None and (resume.parsed_text or "").strip())
+
+    return (
+        jsonify(
+            {
+                "has_preferences": has_roles,
+                "has_resume": has_resume,
+                "roles": roles,
+            }
+        ),
+        200,
+    )
+
+
+@bp.post("/preferences")
+@jwt_required()
+def upsert_preferences():
+    uid = _current_user_id()
+    if uid is None:
+        return jsonify({"error": "Invalid token subject."}), 422
+
+    try:
+        roles = _normalize_roles(request.form.getlist("roles"))
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    resume_file = request.files.get("resume")
+    resume_text = None
+    if resume_file and resume_file.filename:
+        if (resume_file.mimetype or "").lower() not in {
+            "application/pdf",
+            "application/x-pdf",
+        }:
+            return jsonify({"error": "Resume must be a PDF file."}), 400
+
+        file_bytes = resume_file.read()
+        if len(file_bytes) >= MAX_RESUME_BYTES:
+            return jsonify({"error": "Resume must be smaller than 5MB."}), 400
+        try:
+            resume_text = extract_text_from_pdf_bytes(file_bytes)
+        except ResumeParseError as exc:
+            return jsonify({"error": str(exc)}), 400
+
+    pref = db.session.query(UserPreference).filter_by(user_id=uid).one_or_none()
+    if pref is None:
+        pref = UserPreference(
+            user_id=uid,
+            roles=roles,
+            companies=[],
+            locations=[],
+        )
+        db.session.add(pref)
+    else:
+        pref.roles = roles
+
+    if resume_text is not None:
+        resume = db.session.query(Resume).filter_by(user_id=uid).one_or_none()
+        if resume is None:
+            resume = Resume(user_id=uid, parsed_text=resume_text)
+            db.session.add(resume)
+        else:
+            resume.parsed_text = resume_text
+
+    db.session.commit()
+    return jsonify({"message": "Preferences saved successfully."}), 200

--- a/backend/app/services/resume_parser.py
+++ b/backend/app/services/resume_parser.py
@@ -1,0 +1,30 @@
+from io import BytesIO
+
+
+class ResumeParseError(ValueError):
+    pass
+
+
+def extract_text_from_pdf_bytes(file_bytes: bytes) -> str:
+    try:
+        from pypdf import PdfReader
+    except ImportError as exc:  # pragma: no cover - environment-specific
+        raise ResumeParseError(
+            "PDF parsing dependency missing. Install backend requirements."
+        ) from exc
+
+    try:
+        reader = PdfReader(BytesIO(file_bytes))
+    except Exception as exc:  # pragma: no cover - library-specific failures
+        raise ResumeParseError("Could not read PDF resume.") from exc
+
+    text_chunks = []
+    for page in reader.pages:
+        page_text = page.extract_text() or ""
+        if page_text.strip():
+            text_chunks.append(page_text.strip())
+
+    text = "\n".join(text_chunks).strip()
+    if not text:
+        raise ResumeParseError("Resume PDF appears empty or unreadable.")
+    return text

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ pgvector>=0.2.0
 Flask-Migrate>=4.0.0
 numpy>=1.26
 sentence-transformers>=2.7
+pypdf>=4.2

--- a/backend/test_profile_preferences.py
+++ b/backend/test_profile_preferences.py
@@ -1,0 +1,131 @@
+"""Tests for profile preference onboarding endpoints."""
+
+import io
+
+import pytest
+
+from app import create_app
+from app.models import Resume, UserPreference, db
+
+
+@pytest.fixture()
+def app():
+    app = create_app("testing")
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def register_and_token(
+    client, email="pref@example.com", password="correct horse battery staple is great"
+):
+    r = client.post("/api/auth/register", json={"email": email, "password": password})
+    assert r.status_code == 201
+    return r.get_json()["access_token"]
+
+
+def auth_headers(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_preferences_status_false_for_new_user(client):
+    token = register_and_token(client)
+    r = client.get("/api/profile/preferences/status", headers=auth_headers(token))
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["has_preferences"] is False
+    assert body["has_resume"] is False
+    assert body["roles"] == []
+
+
+def test_save_preferences_requires_roles(client):
+    token = register_and_token(client)
+    r = client.post("/api/profile/preferences", headers=auth_headers(token), data={})
+    assert r.status_code == 400
+    assert "role" in r.get_json()["error"].lower()
+
+
+def test_save_preferences_upserts_roles(client, app):
+    token = register_and_token(client)
+    r = client.post(
+        "/api/profile/preferences",
+        headers=auth_headers(token),
+        data={"roles": ["Backend Engineer", "Data Engineer"]},
+    )
+    assert r.status_code == 200
+    with app.app_context():
+        pref = db.session.query(UserPreference).one()
+        assert pref.roles == ["Backend Engineer", "Data Engineer"]
+
+
+def test_save_preferences_rejects_non_pdf_resume(client):
+    token = register_and_token(client)
+    data = {
+        "roles": ["Backend Engineer"],
+        "resume": (io.BytesIO(b"hello"), "resume.txt"),
+    }
+    r = client.post(
+        "/api/profile/preferences",
+        headers=auth_headers(token),
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert r.status_code == 400
+    assert "pdf" in r.get_json()["error"].lower()
+
+
+def test_save_preferences_rejects_too_large_resume(client):
+    token = register_and_token(client)
+    data = {
+        "roles": ["Backend Engineer"],
+        "resume": (io.BytesIO(b"x" * (5 * 1024 * 1024 + 1)), "resume.pdf"),
+    }
+    r = client.post(
+        "/api/profile/preferences",
+        headers=auth_headers(token),
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert r.status_code == 400
+    assert "smaller than 5mb" in r.get_json()["error"].lower()
+
+
+def test_save_preferences_stores_parsed_resume_text(client, app, monkeypatch):
+    token = register_and_token(client)
+
+    def _fake_extract(_file_bytes):
+        return "python flask postgres"
+
+    monkeypatch.setattr(
+        "app.blueprints.profile.routes.extract_text_from_pdf_bytes",
+        _fake_extract,
+    )
+
+    data = {
+        "roles": ["Backend Engineer"],
+        "resume": (io.BytesIO(b"%PDF-1.4 fake"), "resume.pdf"),
+    }
+    r = client.post(
+        "/api/profile/preferences",
+        headers=auth_headers(token),
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert r.status_code == 200
+
+    with app.app_context():
+        resume = db.session.query(Resume).one()
+        assert resume.parsed_text == "python flask postgres"
+
+    status = client.get("/api/profile/preferences/status", headers=auth_headers(token))
+    assert status.status_code == 200
+    body = status.get_json()
+    assert body["has_preferences"] is True
+    assert body["has_resume"] is True

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -4,9 +4,24 @@ import LoginView from '../views/LoginView.vue'
 import RegisterView from '../views/RegisterView.vue'
 import WelcomeView from '../views/WelcomeView.vue'
 import RecommendationsView from '../views/RecommendationsView.vue'
+import PreferencesView from '../views/PreferencesView.vue'
 
 function isAuthenticated() {
   return Boolean(localStorage.getItem('access_token'))
+}
+
+async function fetchPreferenceStatus() {
+  const token = localStorage.getItem('access_token')
+  if (!token) return null
+  try {
+    const res = await fetch('/api/profile/preferences/status', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!res.ok) return null
+    return await res.json()
+  } catch {
+    return null
+  }
 }
 
 const router = createRouter({
@@ -29,17 +44,29 @@ const router = createRouter({
       path: '/recommendations',
       name: 'recommendations',
       component: RecommendationsView,
+      meta: { requiresAuth: true, requiresPreferences: true },
+    },
+    {
+      path: '/preferences',
+      name: 'preferences',
+      component: PreferencesView,
       meta: { requiresAuth: true },
     },
   ],
 })
 
-router.beforeEach((to) => {
+router.beforeEach(async (to) => {
   if (to.meta.requiresAuth && !isAuthenticated()) {
     return { name: 'login', query: { next: to.fullPath } }
   }
   if (to.meta.guestOnly && isAuthenticated()) {
     return { name: 'welcome' }
+  }
+  if (to.meta.requiresPreferences && isAuthenticated()) {
+    const status = await fetchPreferenceStatus()
+    if (!status?.has_preferences) {
+      return { name: 'preferences' }
+    }
   }
   return true
 })

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -64,6 +64,19 @@ const errorMessage = ref('')
 const router = useRouter()
 const route = useRoute()
 
+async function hasPreferences(accessToken) {
+  try {
+    const statusRes = await fetch('/api/profile/preferences/status', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+    if (!statusRes.ok) return false
+    const status = await statusRes.json()
+    return Boolean(status?.has_preferences)
+  } catch {
+    return false
+  }
+}
+
 const handleLogin = async () => {
   errorMessage.value = ''
 
@@ -95,10 +108,16 @@ const handleLogin = async () => {
       localStorage.setItem('refresh_token', data.refresh_token)
     }
 
-    const rawNext = typeof route.query.next === 'string' ? route.query.next : '/welcome'
+    const rawNext = typeof route.query.next === 'string' ? route.query.next : ''
     const safeNext =
-      rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/welcome'
-    router.push(safeNext)
+      rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : ''
+
+    const preferenceExists = await hasPreferences(data.access_token)
+    if (safeNext) {
+      router.push(safeNext)
+      return
+    }
+    router.push(preferenceExists ? '/recommendations' : '/preferences')
   } catch (error) {
     errorMessage.value = error.message
   }

--- a/frontend/src/views/PreferencesView.vue
+++ b/frontend/src/views/PreferencesView.vue
@@ -1,0 +1,252 @@
+<template>
+  <div class="prefs-page">
+    <main class="prefs-card jp-glass">
+      <p class="prefs-kicker">Profile setup</p>
+      <h1 class="prefs-title">Set your job preferences</h1>
+      <p class="prefs-sub">Add at least one role to generate recommendations.</p>
+
+      <form class="prefs-form" @submit.prevent="savePreferences">
+        <div class="field">
+          <label class="jp-label" for="roles">Job roles (required)</label>
+          <div class="role-input-row">
+            <input
+              id="roles"
+              v-model="roleInput"
+              class="jp-input"
+              type="text"
+              placeholder="e.g. Backend Engineer"
+              @keydown.enter.prevent="addRole"
+            />
+            <button type="button" class="jp-btn-secondary" @click="addRole">Add</button>
+          </div>
+          <div class="role-chip-wrap">
+            <span v-for="role in roles" :key="role" class="role-chip">
+              {{ role }}
+              <button type="button" aria-label="Remove role" @click="removeRole(role)">×</button>
+            </span>
+          </div>
+        </div>
+
+        <div class="field">
+          <label class="jp-label" for="resume">Resume (optional PDF, less than 5MB)</label>
+          <input
+            id="resume"
+            ref="resumeInput"
+            class="jp-input"
+            type="file"
+            accept="application/pdf,.pdf"
+            @change="onResumeSelected"
+          />
+          <p class="help-text">Resume is optional but recommended.</p>
+        </div>
+
+        <div v-if="message" class="jp-success">{{ message }}</div>
+        <div v-if="errorMessage" class="jp-error" role="alert">{{ errorMessage }}</div>
+
+        <button class="jp-btn" type="submit" :disabled="saving">
+          {{ saving ? 'Saving...' : 'Save preferences' }}
+        </button>
+      </form>
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const roleInput = ref('')
+const roles = ref([])
+const resumeFile = ref(null)
+const resumeInput = ref(null)
+const errorMessage = ref('')
+const message = ref('')
+const saving = ref(false)
+
+function authHeaders() {
+  const token = localStorage.getItem('access_token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+function addRole() {
+  const next = roleInput.value.trim()
+  if (!next) return
+  if (!roles.value.includes(next)) {
+    roles.value.push(next)
+  }
+  roleInput.value = ''
+}
+
+function removeRole(role) {
+  roles.value = roles.value.filter((r) => r !== role)
+}
+
+function onResumeSelected(event) {
+  errorMessage.value = ''
+  message.value = ''
+  const file = event.target.files?.[0]
+  if (!file) {
+    resumeFile.value = null
+    return
+  }
+  if (file.type !== 'application/pdf') {
+    errorMessage.value = 'Resume must be a PDF file.'
+    resumeFile.value = null
+    if (resumeInput.value) resumeInput.value.value = ''
+    return
+  }
+  if (file.size >= 5 * 1024 * 1024) {
+    errorMessage.value = 'Resume must be smaller than 5MB.'
+    resumeFile.value = null
+    if (resumeInput.value) resumeInput.value.value = ''
+    return
+  }
+  resumeFile.value = file
+}
+
+async function loadExistingStatus() {
+  const res = await fetch('/api/profile/preferences/status', { headers: authHeaders() })
+  if (res.status === 401) {
+    localStorage.removeItem('access_token')
+    localStorage.removeItem('refresh_token')
+    router.replace('/login')
+    return
+  }
+  if (!res.ok) return
+  const body = await res.json()
+  roles.value = Array.isArray(body.roles)
+    ? body.roles.filter((r) => typeof r === 'string' && r.trim())
+    : []
+}
+
+async function savePreferences() {
+  errorMessage.value = ''
+  message.value = ''
+  addRole()
+  if (roles.value.length < 1) {
+    errorMessage.value = 'Add at least one job role.'
+    return
+  }
+  saving.value = true
+  try {
+    const formData = new FormData()
+    for (const role of roles.value) {
+      formData.append('roles', role)
+    }
+    if (resumeFile.value) {
+      formData.append('resume', resumeFile.value)
+    }
+
+    const res = await fetch('/api/profile/preferences', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: formData,
+    })
+    const body = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      throw new Error(body.error || 'Could not save preferences.')
+    }
+    message.value = 'Preferences saved.'
+    router.push('/recommendations')
+  } catch (err) {
+    errorMessage.value = err.message || 'Could not save preferences.'
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(() => {
+  loadExistingStatus()
+})
+</script>
+
+<style scoped>
+.prefs-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.prefs-card {
+  width: min(640px, 100%);
+  padding: 1.5rem;
+}
+
+.prefs-kicker {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--jp-accent2);
+}
+
+.prefs-title {
+  margin: 0.45rem 0 0.25rem;
+  font-size: 1.8rem;
+}
+
+.prefs-sub {
+  margin: 0 0 1.2rem;
+  color: var(--jp-text-muted);
+}
+
+.prefs-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.role-input-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.jp-btn-secondary {
+  border: 1px solid var(--jp-border-soft);
+  border-radius: 12px;
+  padding: 0.55rem 0.9rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.75);
+  cursor: pointer;
+}
+
+.role-chip-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.role-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--jp-primary);
+}
+
+.role-chip button {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: inherit;
+}
+
+.help-text {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--jp-text-muted);
+}
+</style>


### PR DESCRIPTION
## Summary
- add JWT profile endpoints to fetch preference status and upsert roles plus optional resume text using existing `user_preferences` and `resumes` tables
- add PDF parsing helper and validation rules (PDF only, <5MB) plus a new frontend `/preferences` view with required role input and optional resume upload
- gate post-login navigation so users without preferences are redirected to `/preferences`, while users with preferences go to `/recommendations`; update docs and add backend tests

## Test plan
- [x] `cd backend && pytest -q`
- [x] `cd frontend && npm run build`
- [x] Manual flow verified: new user -> `/preferences`, validation errors for missing role/non-PDF/>5MB, save -> `/recommendations`, relogin -> `/recommendations`

Made with [Cursor](https://cursor.com)