### PR TITLE
feat(profile): standardized role options with pill-based selector

### DIFF
--- a/backend/app/blueprints/profile/routes.py
+++ b/backend/app/blueprints/profile/routes.py
@@ -1,11 +1,14 @@
 from flask import jsonify, request
 from flask_jwt_extended import get_jwt_identity, jwt_required
+import re
 
 from app.blueprints.profile import bp
-from app.models import Resume, UserPreference, db
+from app.models import Job, Resume, UserPreference, db
 from app.services.resume_parser import ResumeParseError, extract_text_from_pdf_bytes
 
 MAX_RESUME_BYTES = 5 * 1024 * 1024
+_ROLE_NOISE_RE = re.compile(r"\([^)]*\)")
+_ROLE_SPLIT_RE = re.compile(r"\s*(?:\||/|,| - | — )\s*")
 
 
 def _current_user_id() -> int | None:
@@ -31,9 +34,37 @@ def _normalize_roles(raw_roles) -> list[str]:
     return cleaned
 
 
+def _standardize_role(raw_role: str) -> str:
+    text = (raw_role or "").strip()
+    if not text:
+        return ""
+    text = _ROLE_NOISE_RE.sub("", text).strip()
+    parts = [p.strip() for p in _ROLE_SPLIT_RE.split(text) if p.strip()]
+    return parts[0] if parts else text
+
+
 @bp.get("/health")
 def health():
     return {"blueprint": "profile"}
+
+
+@bp.get("/preferences/role-options")
+@jwt_required()
+def role_options():
+    uid = _current_user_id()
+    if uid is None:
+        return jsonify({"error": "Invalid token subject."}), 422
+
+    role_counts: dict[str, int] = {}
+    rows = db.session.query(Job.role).filter(Job.role.isnot(None)).all()
+    for (raw_role,) in rows:
+        role = _standardize_role(raw_role)
+        if not role:
+            continue
+        role_counts[role] = role_counts.get(role, 0) + 1
+
+    ordered = sorted(role_counts.items(), key=lambda t: (-t[1], t[0].lower()))
+    return jsonify({"roles": [role for role, _count in ordered]}), 200
 
 
 @bp.get("/preferences/status")

--- a/backend/test_profile_preferences.py
+++ b/backend/test_profile_preferences.py
@@ -5,7 +5,7 @@ import io
 import pytest
 
 from app import create_app
-from app.models import Resume, UserPreference, db
+from app.models import Job, Resume, UserPreference, db
 
 
 @pytest.fixture()
@@ -129,3 +129,36 @@ def test_save_preferences_stores_parsed_resume_text(client, app, monkeypatch):
     body = status.get_json()
     assert body["has_preferences"] is True
     assert body["has_resume"] is True
+
+
+def test_role_options_returns_standardized_roles(client, app):
+    token = register_and_token(client)
+    with app.app_context():
+        db.session.add_all(
+            [
+                Job(
+                    role="Software Engineer (Backend) - Remote",
+                    company="acme",
+                    description="d1",
+                ),
+                Job(
+                    role="Software Engineer, Platform",
+                    company="globex",
+                    description="d2",
+                ),
+                Job(
+                    role="Data Scientist | ML",
+                    company="initech",
+                    description="d3",
+                ),
+            ]
+        )
+        db.session.commit()
+
+    r = client.get(
+        "/api/profile/preferences/role-options", headers=auth_headers(token)
+    )
+    assert r.status_code == 200
+    roles = r.get_json()["roles"]
+    assert "Software Engineer" in roles
+    assert "Data Scientist" in roles

--- a/frontend/src/views/PreferencesView.vue
+++ b/frontend/src/views/PreferencesView.vue
@@ -9,22 +9,26 @@
         <div class="field">
           <label class="jp-label" for="roles">Job roles (required)</label>
           <div class="role-input-row">
-            <input
-              id="roles"
-              v-model="roleInput"
-              class="jp-input"
-              type="text"
-              placeholder="e.g. Backend Engineer"
-              @keydown.enter.prevent="addRole"
-            />
+            <select id="roles" v-model="selectedRole" class="jp-input">
+              <option value="" disabled>Select a standardized role</option>
+              <option v-for="role in roleOptions" :key="role" :value="role">
+                {{ role }}
+              </option>
+            </select>
             <button type="button" class="jp-btn-secondary" @click="addRole">Add</button>
           </div>
           <div class="role-chip-wrap">
-            <span v-for="role in roles" :key="role" class="role-chip">
+            <span v-for="role in selectedRoles" :key="role" class="role-chip">
               {{ role }}
               <button type="button" aria-label="Remove role" @click="removeRole(role)">×</button>
             </span>
           </div>
+          <p v-if="!selectedRoles.length" class="help-text">No roles selected yet.</p>
+          <datalist id="role-options-list">
+            <option v-for="role in roleOptions" :key="role" :value="role">
+              {{ role }}
+            </option>
+          </datalist>
         </div>
 
         <div class="field">
@@ -56,8 +60,9 @@ import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
-const roleInput = ref('')
-const roles = ref([])
+const roleOptions = ref([])
+const selectedRole = ref('')
+const selectedRoles = ref([])
 const resumeFile = ref(null)
 const resumeInput = ref(null)
 const errorMessage = ref('')
@@ -69,17 +74,26 @@ function authHeaders() {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
+async function loadRoleOptions() {
+  const res = await fetch('/api/profile/preferences/role-options', { headers: authHeaders() })
+  if (!res.ok) return
+  const body = await res.json()
+  roleOptions.value = Array.isArray(body.roles)
+    ? body.roles.filter((r) => typeof r === 'string' && r.trim())
+    : []
+}
+
 function addRole() {
-  const next = roleInput.value.trim()
-  if (!next) return
-  if (!roles.value.includes(next)) {
-    roles.value.push(next)
+  const role = selectedRole.value
+  if (!role) return
+  if (!selectedRoles.value.includes(role)) {
+    selectedRoles.value.push(role)
   }
-  roleInput.value = ''
+  selectedRole.value = ''
 }
 
 function removeRole(role) {
-  roles.value = roles.value.filter((r) => r !== role)
+  selectedRoles.value = selectedRoles.value.filter((r) => r !== role)
 }
 
 function onResumeSelected(event) {
@@ -115,23 +129,27 @@ async function loadExistingStatus() {
   }
   if (!res.ok) return
   const body = await res.json()
-  roles.value = Array.isArray(body.roles)
+  selectedRoles.value = Array.isArray(body.roles)
     ? body.roles.filter((r) => typeof r === 'string' && r.trim())
     : []
+  for (const role of selectedRoles.value) {
+    if (!roleOptions.value.includes(role)) {
+      roleOptions.value.push(role)
+    }
+  }
 }
 
 async function savePreferences() {
   errorMessage.value = ''
   message.value = ''
-  addRole()
-  if (roles.value.length < 1) {
+  if (selectedRoles.value.length < 1) {
     errorMessage.value = 'Add at least one job role.'
     return
   }
   saving.value = true
   try {
     const formData = new FormData()
-    for (const role of roles.value) {
+    for (const role of selectedRoles.value) {
       formData.append('roles', role)
     }
     if (resumeFile.value) {
@@ -157,7 +175,9 @@ async function savePreferences() {
 }
 
 onMounted(() => {
-  loadExistingStatus()
+  loadRoleOptions()
+    .then(() => loadExistingStatus())
+    .catch(() => {})
 })
 </script>
 


### PR DESCRIPTION
## Summary
- add `GET /api/profile/preferences/role-options` to return standardized, deduplicated role options derived from the current jobs dataset
- introduce backend role standardization to normalize noisy role labels (e.g. parenthetical suffixes and multi-part separators)
- replace preferences free-text role entry with a dropdown + add-pill workflow so users can select multiple roles without keyboard multi-select shortcuts
- add backend test coverage for standardized role option output

## Test plan
- [x] `cd backend && pytest -q`
- [x] `cd frontend && npm run build`
- [x] Manual check: role dropdown loads standardized values, add/remove pills works, preferences save still succeeds

Made with [Cursor](https://cursor.com)