### PR TITLE
fix(embeddings): preload SBERT on startup with persistent local cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Set `EMBEDDING_BACKEND` in `backend/.env`:
 
 - `sbert` (default) — downloads `sentence-transformers/all-MiniLM-L6-v2` (~90 MB) on first use. Real semantic similarity.
 - `hashing` — deterministic SHA1 token-hashing fallback. Used by the test suite and any environment without network access.
+- `PRELOAD_EMBEDDING_MODEL=1` (default) — preloads SBERT during backend startup and caches model files under `backend/.cache/sentence_transformers`, so weights are downloaded once and reused on subsequent runs.
 
 ### Seeding demo data
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,4 @@ FLASK_ENV=development
 SECRET_KEY=change-me
 JWT_SECRET_KEY=change-me-jwt
 DATABASE_URL=postgresql://user:password@host:5432/dbname
+PRELOAD_EMBEDDING_MODEL=1

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 from dotenv import load_dotenv
 load_dotenv()
@@ -8,6 +9,7 @@ from flask_migrate import Migrate
 
 from app.config import config_by_name
 from app.models import db
+from app.services.embeddings import warmup_model
 
 
 
@@ -34,6 +36,21 @@ def create_app(config_name: str | None = None) -> Flask:
     app.register_blueprint(auth_bp, url_prefix="/api/auth")
     app.register_blueprint(profile_bp, url_prefix="/api/profile")
     app.register_blueprint(jobs_bp, url_prefix="/api/jobs")
+
+    should_preload = (
+        config_name != "testing"
+        and os.environ.get("PRELOAD_EMBEDDING_MODEL", "1").strip().lower()
+        not in {"0", "false", "no"}
+    )
+    if should_preload:
+        try:
+            if warmup_model():
+                app.logger.info("SBERT model preloaded and cached on disk.")
+        except Exception as exc:
+            logging.getLogger(__name__).warning(
+                "SBERT preload failed; falling back to lazy load: %s",
+                exc,
+            )
 
     @app.get("/api/health")
     def health():

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+from pathlib import Path
 from typing import Iterable, List
 
 import numpy as np
@@ -24,6 +25,9 @@ import numpy as np
 from app.models import EMBEDDING_DIM, JobEmbedding, ResumeEmbedding
 
 MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+DEFAULT_CACHE_DIR = (
+    Path(__file__).resolve().parents[2] / ".cache" / "sentence_transformers"
+)
 
 _model = None
 
@@ -36,9 +40,22 @@ def get_model():
     """Return (and cache) the SentenceTransformer model."""
     global _model
     if _model is None:
+        cache_dir = Path(
+            os.environ.get("SENTENCE_TRANSFORMERS_HOME", str(DEFAULT_CACHE_DIR))
+        )
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
         from sentence_transformers import SentenceTransformer  # heavy import
-        _model = SentenceTransformer(MODEL_NAME)
+        _model = SentenceTransformer(MODEL_NAME, cache_folder=str(cache_dir))
     return _model
+
+
+def warmup_model() -> bool:
+    """Load SBERT once at startup and keep weights cached on disk."""
+    if _backend() != "sbert":
+        return False
+    get_model()
+    return True
 
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9]+")


### PR DESCRIPTION
## Summary
- preload the sentence-transformer model during backend startup (non-testing envs) to avoid first-request latency spikes
- persist SBERT weights in a local on-disk cache directory so model downloads happen once and are reused across restarts
- add a startup toggle via `PRELOAD_EMBEDDING_MODEL` and keep safe fallback behavior (lazy-load path if preload fails)
- document preload/cache behavior in `.env.example` and README

## Test plan
- [x] `cd backend && pytest -q`
- [x] `cd frontend && npm run build`
- [x] Manual API diagnosis through running backend confirms auth/preferences/recompute endpoints are healthy

Made with [Cursor](https://cursor.com)