### PR TITLE
fix(scraper+recs): clean descriptions and enforce newest-first ties

### DIFF
--- a/backend/app/services/recommender.py
+++ b/backend/app/services/recommender.py
@@ -249,7 +249,12 @@ def get_existing_recommendations(user_id: int) -> List[JobRecommendation]:
         db.session.query(Recommendation, Job)
         .join(Job, Recommendation.job_id == Job.id)
         .filter(Recommendation.user_id == user_id)
-        .order_by(Recommendation.similarity_score.desc())
+        .order_by(
+            Recommendation.similarity_score.desc(),
+            Job.posted_at.desc(),
+            Job.created_at.desc(),
+            Recommendation.computed_at.desc(),
+        )
         .all()
     )
     return [_to_dto(job, rec.similarity_score) for rec, job in rows]

--- a/backend/scrapers/runner.py
+++ b/backend/scrapers/runner.py
@@ -1,4 +1,6 @@
+import html
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -6,6 +8,13 @@ from app.models import Job, db
 from scrapers import SCRAPER_REGISTRY
 
 logger = logging.getLogger(__name__)
+_TAG_RE = re.compile(r"<[^>]+>")
+_LINE_BREAK_TAG_RE = re.compile(r"(?i)<\s*br\s*/?\s*>")
+_BLOCK_CLOSE_TAG_RE = re.compile(r"(?i)</\s*(p|div|section|article|ul|ol|li|h[1-6])\s*>")
+_LI_OPEN_TAG_RE = re.compile(r"(?i)<\s*li\b[^>]*>")
+_SCRIPT_STYLE_RE = re.compile(r"(?is)<\s*(script|style)\b[^>]*>.*?<\s*/\s*\1\s*>")
+_SPACE_RUN_RE = re.compile(r"[ \t]+")
+_BLANK_LINE_RE = re.compile(r"\n{3,}")
 
 
 def parse_location(raw: str) -> tuple[Optional[str], Optional[str], Optional[str]]:
@@ -22,6 +31,27 @@ def parse_location(raw: str) -> tuple[Optional[str], Optional[str], Optional[str
     if len(parts) == 2:
         return (parts[0], parts[1], None)
     return (parts[0], parts[1], ", ".join(parts[2:]))
+
+
+def clean_description(raw: str) -> str:
+    if not raw:
+        return ""
+    text = (
+        html.unescape(raw)
+        .replace("\xa0", " ")
+        .replace("\r\n", "\n")
+        .replace("\r", "\n")
+    )
+    text = _SCRIPT_STYLE_RE.sub(" ", text)
+    text = _LINE_BREAK_TAG_RE.sub("\n", text)
+    text = _BLOCK_CLOSE_TAG_RE.sub("\n", text)
+    text = _LI_OPEN_TAG_RE.sub("\n- ", text)
+    text = _TAG_RE.sub(" ", text)
+    text = _SPACE_RUN_RE.sub(" ", text)
+    lines = [line.strip() for line in text.split("\n")]
+    text = "\n".join(line for line in lines if line)
+    text = _BLANK_LINE_RE.sub("\n\n", text)
+    return text.strip()
 
 
 def run_single_scraper(scraper) -> dict:
@@ -43,11 +73,12 @@ def run_single_scraper(scraper) -> dict:
     for sj in scraped_jobs:
         seen_external_ids.add(sj.external_id)
         city, state, country = parse_location(sj.location)
+        description = clean_description(sj.description)
 
         existing = existing_by_eid.get(sj.external_id)
         if existing is not None:
             existing.role = sj.title
-            existing.description = sj.description
+            existing.description = description
             existing.link = sj.url
             existing.city = city
             existing.state = state
@@ -61,7 +92,7 @@ def run_single_scraper(scraper) -> dict:
                 company=slug,
                 external_id=sj.external_id,
                 role=sj.title,
-                description=sj.description,
+                description=description,
                 link=sj.url,
                 city=city,
                 state=state,

--- a/backend/test_recommender.py
+++ b/backend/test_recommender.py
@@ -283,6 +283,15 @@ class TestServiceLayer:
         scores = [r.similarity_score for r in rows]
         assert scores == sorted(scores, reverse=True)
 
+    def test_get_existing_role_only_prefers_latest_posted(self, app):
+        user, _ = make_user()
+        make_pref(user.id, roles=["Engineer"])
+        make_job("Engineer", "OldCo", "old", posted_at=date(2026, 1, 1))
+        make_job("Engineer", "NewCo", "new", posted_at=date(2026, 3, 1))
+        recommend_for_user(user.id)
+        rows = get_existing_recommendations(user.id)
+        assert [r.company for r in rows] == ["NewCo", "OldCo"]
+
 
 # ───────────────────────────── api tests ────────────────────────────────────
 class TestRecommendationsApi:

--- a/backend/test_runner.py
+++ b/backend/test_runner.py
@@ -11,7 +11,12 @@ import pytest
 from app import create_app
 from app.models import Job, db
 from scrapers.base import ScrapedJob
-from scrapers.runner import parse_location, run_all_scrapers, run_single_scraper
+from scrapers.runner import (
+    clean_description,
+    parse_location,
+    run_all_scrapers,
+    run_single_scraper,
+)
 
 
 # ── parse_location ──────────────────────────────────────────────────
@@ -41,6 +46,26 @@ class TestParseLocation:
 
     def test_strips_whitespace(self):
         assert parse_location("  Paris ,  IdF , France ") == ("Paris", "IdF", "France")
+
+
+class TestCleanDescription:
+    def test_strips_html_and_unescapes_entities(self):
+        raw = "<div>Hello&nbsp;<b>World</b> &amp; team</div>"
+        assert clean_description(raw) == "Hello World & team"
+
+    def test_preserves_readable_structure_for_breaks_and_lists(self):
+        raw = (
+            "<h2>About the role</h2>"
+            "<p>Build systems<br/>with Python.</p>"
+            "<ul><li>Design APIs</li><li>Improve reliability</li></ul>"
+        )
+        assert clean_description(raw) == (
+            "About the role\n"
+            "Build systems\n"
+            "with Python.\n"
+            "- Design APIs\n"
+            "- Improve reliability"
+        )
 
 
 # ── Runner integration tests ────────────────────────────────────────
@@ -95,6 +120,7 @@ class TestRunSingleScraper:
         assert len(rows) == 2
         r = rows[0]
         assert r.role == "Backend"
+        assert r.description == "desc"
         assert r.link == "https://example.com/101"
         assert r.city == "San Francisco"
         assert r.state == "CA"
@@ -124,6 +150,41 @@ class TestRunSingleScraper:
         assert rows[0].role == "New Title"
         assert rows[0].link == "https://example.com/101"
         assert rows[0].last_seen_at is not None
+
+    def test_cleans_html_description_on_insert_and_update(self, app):
+        scraper = FakeScraper(
+            "airbnb",
+            [
+                ScrapedJob(
+                    external_id="201",
+                    title="Backend",
+                    location="Remote",
+                    description="<p>Build&nbsp;<b>APIs</b> &amp; services</p>",
+                    url="https://example.com/201",
+                    date_posted=date(2026, 4, 1),
+                )
+            ],
+        )
+        run_single_scraper(scraper)
+        row = Job.query.filter_by(company="airbnb", external_id="201").one()
+        assert row.description == "Build APIs & services"
+
+        scraper2 = FakeScraper(
+            "airbnb",
+            [
+                ScrapedJob(
+                    external_id="201",
+                    title="Backend",
+                    location="Remote",
+                    description="<div>Own <i>platform</i> reliability</div>",
+                    url="https://example.com/201",
+                    date_posted=date(2026, 4, 1),
+                )
+            ],
+        )
+        run_single_scraper(scraper2)
+        row2 = Job.query.filter_by(company="airbnb", external_id="201").one()
+        assert row2.description == "Own platform reliability"
 
     def test_deactivates_unseen_jobs(self, app):
         db.session.add_all([

--- a/frontend/src/stores/recommendations.js
+++ b/frontend/src/stores/recommendations.js
@@ -15,9 +15,18 @@ export const useRecommendationsStore = defineStore('recommendations', {
   }),
   getters: {
     sortedByScore(state) {
-      return [...state.items].sort(
-        (a, b) => (b.similarity_score || 0) - (a.similarity_score || 0),
-      )
+      const parseTs = (value) => {
+        if (!value) return 0
+        const ts = Date.parse(value)
+        return Number.isNaN(ts) ? 0 : ts
+      }
+      return [...state.items].sort((a, b) => {
+        const scoreDelta = (b.similarity_score || 0) - (a.similarity_score || 0)
+        if (scoreDelta !== 0) return scoreDelta
+        const postedDelta = parseTs(b.posted_at) - parseTs(a.posted_at)
+        if (postedDelta !== 0) return postedDelta
+        return (b.job_id || 0) - (a.job_id || 0)
+      })
     },
   },
   actions: {

--- a/frontend/src/views/RecommendationsView.vue
+++ b/frontend/src/views/RecommendationsView.vue
@@ -185,8 +185,9 @@ function formatDate(iso) {
 
 function snippet(text, max = 220) {
   if (!text) return ''
-  if (text.length <= max) return text
-  return `${text.slice(0, max).trimEnd()}…`
+  const normalized = text.replace(/\n{3,}/g, '\n\n').trim()
+  if (normalized.length <= max) return normalized
+  return `${normalized.slice(0, max).trimEnd()}…`
 }
 
 function openDetails(rec) {
@@ -438,6 +439,7 @@ onMounted(() => {
   font-size: 0.92rem;
   line-height: 1.55;
   color: var(--jp-text-muted);
+  white-space: pre-line;
 }
 
 .recs-card-actions,


### PR DESCRIPTION
## Summary
- Clean scraped job descriptions during ingestion by stripping HTML while preserving readable structure (line breaks and bullet points).
- Keep recommendation text formatting readable in the UI card snippets.
- Fix recommendation ordering ties (especially role-only 100% matches) to prefer newer postings in both backend retrieval and frontend display.

## Test plan
- [x] `cd backend && pytest -q test_runner.py`
- [x] `cd backend && pytest -q test_recommender.py`
- [x] `cd backend && pytest -q`
- [x] `cd frontend && npm run build`

Made with [Cursor](https://cursor.com)