### PR TITLE
fix(recs): improve resume matching and recency-first recommendation order

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,24 @@ The preferences form saves through `POST /api/profile/preferences` and enforces:
 ### How matching works
 
 1. Read `user_preferences` for the caller. **At least one role** is required (FR6.1) — otherwise the API returns `400 {"code": "missing_role_preferences"}`.
-2. Filter `jobs` by case-insensitive role match (always) and company match (when companies are set).
-3. Build the user vector — embed the uploaded resume text if present (FR6.2), or a synthesized "Looking for roles: …" string from the preferences if not (FR6.3).
-4. For each candidate job, fetch (or compute and cache) a 384-dim vector of its description.
-5. Score by cosine similarity, keep `>= 0.80`, persist into the `recommendations` table, and return sorted descending (FR6.4).
+2. Filter `jobs` by standardized role match (always) and company match (when companies are set).
+3. If no resume exists:
+   - vector logic is bypassed entirely;
+   - candidates are ranked by recency (`posted_at` desc, then `created_at` desc);
+   - score is set to `1.0` (100%) for each returned row.
+4. If a resume exists:
+   - build a resume embedding from normalized resume text plus extracted key terms;
+   - build/fetch each job embedding from `role + company + description`;
+   - compute a raw hybrid score:
+     - `semantic = (cosine + 1) / 2`
+     - `overlap = |resume_terms ∩ job_terms| / |resume_terms|`
+     - `raw = 0.70 * semantic + 0.30 * overlap`
+   - sort by `raw` descending.
+5. Calibrate resume-mode display scores to a user-friendly range while preserving ranking order:
+   - `calibrated = 0.55 + ((raw - min_raw) / (max_raw - min_raw)) * (0.98 - 0.55)`
+   - if all raw scores are equal, apply a very small rank-based decay from `0.98` down toward `0.55`.
+6. Apply a resume-mode threshold and keep only rows with `score >= 0.80` (default `SIMILARITY_THRESHOLD`).
+7. Persist results into `recommendations` and return rows sorted by recency (`posted_at`, then `created_at`). Similarity score is used for filtering/scoring, not final ordering.
 
 ### Local Postgres + pgvector
 

--- a/backend/app/services/recommender.py
+++ b/backend/app/services/recommender.py
@@ -9,9 +9,9 @@ Pipeline (FR6, US-6):
      candidate job has a cached vector.
   4. Rank candidates:
        - no resume: by ``posted_at`` desc, then ``created_at`` desc
-       - with resume: by cosine similarity desc
+      - with resume: compute score, then final sort by recency
      and persist rows into the ``recommendations`` table.
-  5. Return the rows sorted descending by similarity (FR6.4).
+  5. Return rows sorted by recency.
 
 Public surface:
 
@@ -46,6 +46,16 @@ from app.services.embeddings import (
 SIMILARITY_THRESHOLD = 0.80
 _ROLE_NOISE_RE = re.compile(r"\([^)]*\)")
 _ROLE_SPLIT_RE = re.compile(r"\s*(?:\||/|,| - | — )\s*")
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9+#.\-]*")
+_STOPWORDS = {
+    "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "in",
+    "into", "is", "it", "of", "on", "or", "that", "the", "to", "with",
+    "you", "your", "we", "our", "this", "will", "can", "have", "has",
+}
+_SEMANTIC_WEIGHT = 0.70
+_OVERLAP_WEIGHT = 0.30
+_CALIBRATED_MIN = 0.55
+_CALIBRATED_MAX = 0.98
 
 
 class RecommenderError(Exception):
@@ -124,10 +134,21 @@ def _resume_text(user_id: int) -> Optional[str]:
     return text or None
 
 
+def _prepare_resume_text_for_embedding(text: str) -> str:
+    """Compact resume text so embeddings focus on strongest signals."""
+    cleaned = " ".join((text or "").split())
+    terms = sorted(_extract_terms(cleaned))
+    if not terms:
+        return cleaned
+    top_terms = ", ".join(terms[:80])
+    return f"{cleaned}\n\nKey skills and terms: {top_terms}"
+
+
 def _compute_resume_vector(user_id: int, text: str) -> List[float]:
     """Return resume vector and refresh ResumeEmbedding cache."""
+    embedding_text = _prepare_resume_text_for_embedding(text)
     upsert_resume_embedding(
-        db.session, user_id, text, source="resume"
+        db.session, user_id, embedding_text, source="resume"
     )
     db.session.flush()
     emb = db.session.get(ResumeEmbedding, user_id)
@@ -164,10 +185,82 @@ def _filter_candidate_jobs(roles: List[str], companies: List[str]) -> List[Job]:
 def _ensure_job_vector(job: Job) -> List[float]:
     emb = db.session.get(JobEmbedding, job.id)
     if emb is None:
-        upsert_job_embedding(db.session, job.id, job.description or "")
+        upsert_job_embedding(
+            db.session,
+            job.id,
+            _prepare_job_text_for_embedding(job),
+        )
         db.session.flush()
         emb = db.session.get(JobEmbedding, job.id)
     return list(emb.embedding)
+
+
+def _prepare_job_text_for_embedding(job: Job) -> str:
+    parts = [job.role or "", job.company or "", job.description or ""]
+    return " ".join(p.strip() for p in parts if p and p.strip())
+
+
+def _extract_terms(text: str) -> set[str]:
+    terms: set[str] = set()
+    for token in _TOKEN_RE.findall((text or "").lower()):
+        if len(token) < 2 or token in _STOPWORDS:
+            continue
+        terms.add(token)
+    return terms
+
+
+def _skill_overlap_score(resume_text: str, job: Job) -> float:
+    resume_terms = _extract_terms(resume_text)
+    if not resume_terms:
+        return 0.0
+    job_terms = _extract_terms(_prepare_job_text_for_embedding(job))
+    if not job_terms:
+        return 0.0
+    overlap = len(resume_terms & job_terms)
+    # Recall-style overlap: how much of candidate profile appears in the job.
+    return overlap / len(resume_terms)
+
+
+def _hybrid_score(cosine: float, overlap: float) -> float:
+    semantic = max(-1.0, min(1.0, cosine))
+    semantic_01 = (semantic + 1.0) / 2.0
+    score = (_SEMANTIC_WEIGHT * semantic_01) + (_OVERLAP_WEIGHT * overlap)
+    return max(0.0, min(1.0, score))
+
+
+def _calibrate_resume_scores(
+    scored: List[tuple[Job, float]]
+) -> List[tuple[Job, float]]:
+    """Map raw hybrid scores into a user-friendly percentage band.
+
+    Calibration is monotonic, so ranking order is preserved.
+    """
+    if not scored:
+        return scored
+
+    raws = [score for _job, score in scored]
+    lo = min(raws)
+    hi = max(raws)
+    spread = hi - lo
+
+    if spread <= 1e-8:
+        # Degenerate case: equal raw scores. Use a gentle rank decay so
+        # list order remains stable and scores do not all display identical.
+        out: List[tuple[Job, float]] = []
+        step = min(0.01, (_CALIBRATED_MAX - _CALIBRATED_MIN) / max(len(scored), 1))
+        for idx, (job, _raw) in enumerate(scored):
+            calibrated = max(_CALIBRATED_MIN, _CALIBRATED_MAX - (idx * step))
+            out.append((job, calibrated))
+        return out
+
+    out: List[tuple[Job, float]] = []
+    for job, raw in scored:
+        norm = (raw - lo) / spread
+        calibrated = _CALIBRATED_MIN + (
+            (_CALIBRATED_MAX - _CALIBRATED_MIN) * norm
+        )
+        out.append((job, max(0.0, min(1.0, calibrated))))
+    return out
 
 
 def _to_dto(job: Job, score: float) -> JobRecommendation:
@@ -230,8 +323,12 @@ def recommend_for_user(
             if job_norm == 0.0:
                 continue
             cos = float(np.dot(user_arr, job_arr) / (user_norm * job_norm))
-            scored.append((job, cos))
+            overlap = _skill_overlap_score(resume_text, job)
+            scored.append((job, _hybrid_score(cos, overlap)))
         scored.sort(key=lambda t: t[1], reverse=True)
+        scored = _calibrate_resume_scores(scored)
+        scored = [(job, score) for job, score in scored if score >= threshold]
+        scored.sort(key=lambda t: _job_recency_key(t[0]), reverse=True)
 
     for job, score in scored:
         db.session.add(
@@ -250,9 +347,9 @@ def get_existing_recommendations(user_id: int) -> List[JobRecommendation]:
         .join(Job, Recommendation.job_id == Job.id)
         .filter(Recommendation.user_id == user_id)
         .order_by(
-            Recommendation.similarity_score.desc(),
             Job.posted_at.desc(),
             Job.created_at.desc(),
+            Recommendation.similarity_score.desc(),
             Recommendation.computed_at.desc(),
         )
         .all()

--- a/backend/test_recommender.py
+++ b/backend/test_recommender.py
@@ -4,7 +4,7 @@ Covers:
   - FR6.1   minimum input (at least one preferred role)
   - FR6.2   matching uses preferences and resume content
   - FR6.3   no-resume mode uses lexical role matching + recency ordering
-  - FR6.4   recommendations are sorted by similarity (desc)
+  - FR6.4   recommendations are sorted by recency (desc)
   - Role phrase match gates inclusion; similarity ranks results
   - Filter by role and company
   - Persistence in the recommendations table (Table 3)
@@ -130,11 +130,11 @@ class TestServiceLayer:
         db.session.commit()
         recs = recommend_for_user(user.id)
         assert len(recs) == 1
-        assert recs[0].similarity_score >= 0.99
+        assert recs[0].similarity_score >= 0.80
         emb = db.session.get(ResumeEmbedding, user.id)
         assert emb.source == "resume"
 
-    def test_role_phrase_match_includes_low_scoring_jobs(self, app):
+    def test_resume_mode_applies_similarity_threshold(self, app):
         user, _ = make_user()
         make_pref(user.id, roles=["Backend Engineer"])
         make_job(
@@ -152,23 +152,37 @@ class TestServiceLayer:
         )
         db.session.commit()
         recs = recommend_for_user(user.id)
-        assert len(recs) == 2
-        assert {r.company for r in recs} == {"Acme", "Initech"}
-        assert recs[0].similarity_score >= recs[1].similarity_score
+        assert len(recs) == 1
+        assert {r.company for r in recs} == {"Acme"}
+        assert recs[0].similarity_score >= SIMILARITY_THRESHOLD
 
-    def test_fr6_4_results_sorted_by_similarity_desc(self, app):
+    def test_fr6_4_resume_results_sorted_by_posted_date_desc(self, app):
         user, _ = make_user()
         make_pref(user.id, roles=["Engineer"])
-        make_job("Engineer", "A", "python flask postgres backend api")
-        make_job("Engineer", "B", "python flask postgres backend service")
-        make_job("Engineer", "C", "python flask")
+        make_job(
+            "Engineer",
+            "OldCo",
+            "python flask postgres backend api",
+            posted_at=date(2026, 1, 1),
+        )
+        make_job(
+            "Engineer",
+            "NewCo",
+            "python flask postgres backend service",
+            posted_at=date(2026, 3, 1),
+        )
+        make_job(
+            "Engineer",
+            "MidCo",
+            "python flask",
+            posted_at=date(2026, 2, 1),
+        )
         db.session.add(
             Resume(user_id=user.id, parsed_text="python flask postgres backend api")
         )
         db.session.commit()
         recs = recommend_for_user(user.id, threshold=0.0)
-        scores = [r.similarity_score for r in recs]
-        assert scores == sorted(scores, reverse=True)
+        assert [r.company for r in recs] == ["NewCo", "MidCo", "OldCo"]
 
     def test_filter_by_role_applies(self, app):
         user, _ = make_user()
@@ -240,7 +254,7 @@ class TestServiceLayer:
             db.session.query(Recommendation).filter_by(user_id=user.id).all()
         )
         assert len(rows) == 1
-        assert rows[0].similarity_score >= SIMILARITY_THRESHOLD
+        assert rows[0].similarity_score > 0.0
 
     def test_recompute_replaces_old_rows(self, app):
         user, _ = make_user()
@@ -274,14 +288,13 @@ class TestServiceLayer:
     def test_get_existing_returns_sorted_without_recomputing(self, app):
         user, _ = make_user()
         make_pref(user.id, roles=["Engineer"])
-        make_job("Engineer", "A", "python flask postgres")
-        make_job("Engineer", "B", "python flask")
+        make_job("Engineer", "OldCo", "python flask postgres", posted_at=date(2026, 1, 1))
+        make_job("Engineer", "NewCo", "python flask", posted_at=date(2026, 2, 1))
         db.session.add(Resume(user_id=user.id, parsed_text="python flask postgres"))
         db.session.commit()
         recommend_for_user(user.id, threshold=0.0)
         rows = get_existing_recommendations(user.id)
-        scores = [r.similarity_score for r in rows]
-        assert scores == sorted(scores, reverse=True)
+        assert [r.company for r in rows] == ["NewCo", "OldCo"]
 
     def test_get_existing_role_only_prefers_latest_posted(self, app):
         user, _ = make_user()

--- a/frontend/src/stores/recommendations.js
+++ b/frontend/src/stores/recommendations.js
@@ -21,10 +21,10 @@ export const useRecommendationsStore = defineStore('recommendations', {
         return Number.isNaN(ts) ? 0 : ts
       }
       return [...state.items].sort((a, b) => {
-        const scoreDelta = (b.similarity_score || 0) - (a.similarity_score || 0)
-        if (scoreDelta !== 0) return scoreDelta
         const postedDelta = parseTs(b.posted_at) - parseTs(a.posted_at)
         if (postedDelta !== 0) return postedDelta
+        const scoreDelta = (b.similarity_score || 0) - (a.similarity_score || 0)
+        if (scoreDelta !== 0) return scoreDelta
         return (b.job_id || 0) - (a.job_id || 0)
       })
     },


### PR DESCRIPTION
## Summary
- Improve resume-to-job relevance with hybrid scoring (semantic similarity + lexical overlap) using enriched resume/job embedding text.
- Calibrate resume-mode scores to a user-friendly range, and enforce the `0.80` threshold for resume-mode inclusion.
- Make final recommendation ordering newest-first (`posted_at`, then `created_at`) in both backend retrieval and frontend display.
- Update recommendation tests and README documentation for the new scoring/ordering behavior.

## Test plan
- [x] `cd backend && pytest -q test_recommender.py`
- [x] `cd backend && pytest -q`
- [x] `cd frontend && npm run build`
- [x] Manual API sanity checks with sample resumes (`Bhiman_Resume.pdf`, `Palak_CV.pdf`)

Made with [Cursor](https://cursor.com)